### PR TITLE
fix pre commit config order

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,25 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/google/addlicense
+    rev: "499ed7f28389eb4a08c2d7e40b1637cfd7f65381"
+    hooks:
+      - id: addlicense
+        args:
+          [
+            "-c",
+            "EvoBandits",
+            "-ignore",
+            "yaml",
+            "-ignore",
+            "md",
+            "-ignore",
+            "toml",
+            "-ignore",
+            "yml",
+            "-ignore",
+            ".pre-commit-config.yaml",
+          ]
   - repo: local
     hooks:
       - id: cargo-fmt
@@ -35,22 +54,3 @@ repos:
         types_or: [python, pyi, jupyter]
         args: []
         minimum_pre_commit_version: "2.9.2"
-  - repo: https://github.com/google/addlicense
-    rev: "499ed7f28389eb4a08c2d7e40b1637cfd7f65381"
-    hooks:
-      - id: addlicense
-        args:
-          [
-            "-c",
-            "EvoBandits",
-            "-ignore",
-            "yaml",
-            "-ignore",
-            "md",
-            "-ignore",
-            "toml",
-            "-ignore",
-            "yml",
-            "-ignore",
-            ".pre-commit-config.yaml",
-          ]


### PR DESCRIPTION
Depending on the number of newlines at the beginning of a file, ruff-format tries to add a newline directly after a new license header from addlicense. This means that changes can only be commited on the 3rd attempt in some cases.

This can be avoided, if the license is added before ruff-format.