### PR TITLE
105 modify ouput and variable names

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -13,11 +13,11 @@ A discrete, integer decision vector that represents a distinct solution of the o
 
 #### Bounds
 
-A list of tuples that define the lower and upper bounds for each value of the action vector, and therefore, constrain the solution space for the optimization with EvoBandits. For problems that are modeled using the Python API, the bounds are derived from the specifications for the individual decision parameters that build the action vector.
+Bounds are defined as a list of tuples, where each tuple specifies the lower and upper limits for a value in the action vector. These bounds constrain the solution space for optimization with EvoBandits. When using the Python API, the bounds are derived from the specifications of the individual decision parameters that make up the action vector.
 
 #### Encoding / Decoding
 
-If the user defines a solution space using the Python API, an encoding step is necessary to convert the solution to an action vector that is usable for optimization with EvoBandits. This step is trivial for integer parameters; however, a discretization step for float parameters and label encoding for categorical parameters is required.
+If the user defines a solution space using the Python API, an encoding step is necessary to convert the solution to an action vector that is usable for optimization with EvoBandits. This step is trivial for integer parameters; however, a discretization step (converting continuous values into discrete intervals) for float parameters and label encoding (assigning unique integer values to categorical data) for categorical parameters is required.
 
 #### EvoBandits Algorithm Options
 
@@ -29,13 +29,15 @@ The user can modify the conditions for the optimization using the following keyw
 
 #### Optimization Function
 
-The optimization function (also: 'objective', or 'func') is defined by the user and **evaluated** multiple times during optimization with EvoBandits. The user also specifies constraints for the solution space (as decision parameters using the Python API or directly as bounds), as well as the conditions (for example, the simulation budget) for the optimization.
+The optimization function (also: 'objective', or 'func') is defined by the user and **evaluated** multiple times during optimization with EvoBandits. The user also specifies constraints for the solution space (as decision parameters using the Python API or directly as bounds), as well as the conditions for the optimization:
+- The budget, or number of function evaluations before the optimization stops is set using `n_trials`. A trial stands for a single evaluation of the optimization function.
 
 #### Results
 
 In the context of EvoBandits, a multi-armed bandit algorithm, each result is internally represented by an `Arm`. During optimization, each arm is pulled, i.e. the result is chosen by the algorithm, evaluated with the objective function, and its value is observed and saved. After optimization, the best results are returned.
 
-Users can assess the quality of each distinct results with the following metrics:
+Users can assess distinct results with the following metrics:
+- `params`: The distinct parameter configuration for the result.
 - `value`: The objective value of the result observed during optimization. In the case of the EvoBandits algorithm, the value is the mean of all evaluation results.
 - `n_evaluations`: The number of times a result has been evaluated during optimization. This metric tracks how much experience the algorithm has with each result (or Arm) and indicates whether a result has been explored or exploited by the algorithm.
 - `n_best`: The rank of the result in the respective optimization run. The best configuration is marked with n_best = 1.
@@ -44,9 +46,3 @@ Users can assess the quality of each distinct results with the following metrics
 
 The user can define a `seed` to ensure deterministic behaviour and reproduce optimization results (under certain conditions).
 Per default, the optimization is unseeded, and system entropy is used instead.
-
-#### Trial
-
-With respect to the Python API, a trial stands for a single evaluation of the optimization function. This is closely connected to the following keywords:
-- `trials`: The budget, or number of function evaluations for the optimization.
-- `best_trial`: The parameters with the best evaluation result from the optimization.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -31,13 +31,22 @@ The user can modify the conditions for the optimization using the following keyw
 
 The optimization function (also: 'objective', or 'func') is defined by the user and **evaluated** multiple times during optimization with EvoBandits. The user also specifies constraints for the solution space (as decision parameters using the Python API or directly as bounds), as well as the conditions (for example, the simulation budget) for the optimization.
 
-#### Trial
+#### Results
 
-With respect to the Python API, a trial stands for a single evaluation of the optimization function. This is closely connected to the following keywords:
-- `trials`: The budget, or number of function evaluations for the optimization.
-- `best_trial`: The parameters with the best evaluation result from the optimization.
+In the context of EvoBandits, a multi-armed bandit algorithm, each result is internally represented by an `Arm`. During optimization, each arm is pulled, i.e. the result is chosen by the algorithm, evaluated with the objective function, and its value is observed and saved. After optimization, the best results are returned.
+
+Users can assess the quality of each distinct results with the following metrics:
+- `value`: The objective value of the result observed during optimization. In the case of the EvoBandits algorithm, the value is the mean of all evaluation results.
+- `n_evaluations`: The number of times a result has been evaluated during optimization. This metric tracks how much experience the algorithm has with each result (or Arm) and indicates whether a result has been explored or exploited by the algorithm.
+- `n_best`: The rank of the result in the respective optimization run. The best configuration is marked with n_best = 1.
 
 #### Seeding
 
 The user can define a `seed` to ensure deterministic behaviour and reproduce optimization results (under certain conditions).
 Per default, the optimization is unseeded, and system entropy is used instead.
+
+#### Trial
+
+With respect to the Python API, a trial stands for a single evaluation of the optimization function. This is closely connected to the following keywords:
+- `trials`: The budget, or number of function evaluations for the optimization.
+- `best_trial`: The parameters with the best evaluation result from the optimization.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ def test_function(number: list) -> float:
 if __name__ == '__main__':
     bounds = [(-5, 10), (-5, 10)]
     evobandits = EvoBandits(test_function, bounds)
-    evaluation_budget = 10000
-    result = evobandits.optimize(evaluation_budget)
+    n_trials = 10000
+    result = evobandits.optimize(n_trials)
     print(result)
 ```
 

--- a/evobandits/benches/evobandits_benchmark.rs
+++ b/evobandits/benches/evobandits_benchmark.rs
@@ -41,24 +41,28 @@ fn benchmark_evobandits(c: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(60));
 
     // Simulate different budgets
-    for budget in [10_000, 100_000].iter() {
-        group.bench_with_input(BenchmarkId::new("Noisy", budget), budget, |b, &budget| {
-            b.iter(|| {
-                let mut evobandits = EvoBandits::new(Default::default());
-                let bounds = vec![(-50, 50), (-50, 50)];
+    for n_trials in [10_000, 100_000].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("Noisy", n_trials),
+            n_trials,
+            |b, &n_trials| {
+                b.iter(|| {
+                    let mut evobandits = EvoBandits::new(Default::default());
+                    let bounds = vec![(-50, 50), (-50, 50)];
 
-                // Run the optimization
-                let result = evobandits.optimize(
-                    black_box(noisy_rosenbrock),
-                    black_box(bounds),
-                    black_box(budget),
-                    1,
-                    Default::default(),
-                );
+                    // Run the optimization
+                    let result = evobandits.optimize(
+                        black_box(noisy_rosenbrock),
+                        black_box(bounds),
+                        black_box(n_trials),
+                        1,
+                        Default::default(),
+                    );
 
-                result
-            });
-        });
+                    result
+                });
+            },
+        );
     }
 
     group.finish();

--- a/evobandits/examples/inventory.rs
+++ b/evobandits/examples/inventory.rs
@@ -1076,7 +1076,7 @@ fn main() {
         let start_time = Instant::now(); // Record the start time
         let bounds = vec![(1, 100), (1, 100)]; // Set the bounds for the problem
         let mut evobandits = EvoBandits::new(Default::default()); // Initialize a default EvoBandits Instance
-        let best_arms = evobandits.optimize(inventory, bounds, 10000, 1, None); // Optimize inventory, unseeded, with constraints (bounds, budget)
+        let best_arms = evobandits.optimize(inventory, bounds, 10000, 1, None); // Optimize inventory, unseeded, with constraints (bounds, n_trials)
 
         let elapsed_time = start_time.elapsed().as_secs_f64(); // Record the elapsed time
         total_time += elapsed_time; // Add the elapsed time to the total

--- a/evobandits/src/arm.rs
+++ b/evobandits/src/arm.rs
@@ -27,7 +27,7 @@ impl<F: Fn(&[i32]) -> f64> OptimizationFn for F {
 #[derive(Debug)]
 pub struct Arm {
     action_vector: Vec<i32>,
-    reward: f64,
+    reward: f64, // TODO Issue #101: directly track value with Welford's algorithm
     n_evaluations: i32,
 }
 
@@ -61,7 +61,7 @@ impl Arm {
         &self.action_vector
     }
 
-    pub fn get_mean_reward(&self) -> f64 {
+    pub fn get_value(&self) -> f64 {
         if self.n_evaluations == 0 {
             return 0.0;
         }
@@ -116,7 +116,7 @@ mod tests {
 
         assert_eq!(reward, 5.0);
         assert_eq!(arm.get_n_evaluations(), 1);
-        assert_eq!(arm.get_mean_reward(), 5.0);
+        assert_eq!(arm.get_value(), 5.0);
     }
 
     #[test]
@@ -126,7 +126,7 @@ mod tests {
         arm.pull(&mock_opti_function);
 
         assert_eq!(arm.get_n_evaluations(), 2);
-        assert_eq!(arm.get_mean_reward(), 5.0); // Since reward is always 5.0
+        assert_eq!(arm.get_value(), 5.0); // Since reward is always 5.0
     }
 
     #[test]
@@ -145,13 +145,13 @@ mod tests {
     #[test]
     fn test_initial_reward_is_zero() {
         let arm = Arm::new(&vec![1, 2]);
-        assert_eq!(arm.get_mean_reward(), 0.0);
+        assert_eq!(arm.get_value(), 0.0);
     }
 
     #[test]
-    fn test_mean_reward_with_zero_pulls() {
+    fn test_value_with_zero_pulls() {
         let arm = Arm::new(&vec![1, 2]);
-        assert_eq!(arm.get_mean_reward(), 0.0);
+        assert_eq!(arm.get_value(), 0.0);
     }
 
     #[test]
@@ -160,6 +160,6 @@ mod tests {
         arm.pull(&mock_opti_function);
         let cloned_arm = arm.clone();
         assert_eq!(arm.get_n_evaluations(), cloned_arm.get_n_evaluations());
-        assert_eq!(arm.get_mean_reward(), cloned_arm.get_mean_reward());
+        assert_eq!(arm.get_value(), cloned_arm.get_value());
     }
 }

--- a/evobandits/src/arm.rs
+++ b/evobandits/src/arm.rs
@@ -1,3 +1,17 @@
+// Copyright 2025 EvoBandits
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::hash::{Hash, Hasher};
 
 pub trait OptimizationFn {
@@ -14,14 +28,14 @@ impl<F: Fn(&[i32]) -> f64> OptimizationFn for F {
 pub struct Arm {
     action_vector: Vec<i32>,
     reward: f64,
-    num_pulls: i32,
+    n_evaluations: i32,
 }
 
 impl Arm {
     pub fn new(action_vector: &[i32]) -> Self {
         Self {
             reward: 0.0,
-            num_pulls: 0,
+            n_evaluations: 0,
             action_vector: action_vector.to_vec(),
         }
     }
@@ -30,13 +44,13 @@ impl Arm {
         let g = opt_fn.evaluate(&self.action_vector);
 
         self.reward += g;
-        self.num_pulls += 1;
+        self.n_evaluations += 1;
 
         g
     }
 
-    pub fn get_num_pulls(&self) -> i32 {
-        self.num_pulls
+    pub fn get_n_evaluations(&self) -> i32 {
+        self.n_evaluations
     }
 
     pub(crate) fn get_function_value<F: OptimizationFn>(&self, opt_fn: &F) -> f64 {
@@ -48,10 +62,10 @@ impl Arm {
     }
 
     pub fn get_mean_reward(&self) -> f64 {
-        if self.num_pulls == 0 {
+        if self.n_evaluations == 0 {
             return 0.0;
         }
-        self.reward / self.num_pulls as f64
+        self.reward / self.n_evaluations as f64
     }
 }
 
@@ -60,7 +74,7 @@ impl Clone for Arm {
         Self {
             action_vector: self.action_vector.clone(),
             reward: self.reward,
-            num_pulls: self.num_pulls,
+            n_evaluations: self.n_evaluations,
         }
     }
 }
@@ -91,7 +105,7 @@ mod tests {
     #[test]
     fn test_arm_new() {
         let arm = Arm::new(&vec![1, 2]);
-        assert_eq!(arm.get_num_pulls(), 0);
+        assert_eq!(arm.get_n_evaluations(), 0);
         assert_eq!(arm.get_function_value(&mock_opti_function), 5.0);
     }
 
@@ -101,7 +115,7 @@ mod tests {
         let reward = arm.pull(&mock_opti_function);
 
         assert_eq!(reward, 5.0);
-        assert_eq!(arm.get_num_pulls(), 1);
+        assert_eq!(arm.get_n_evaluations(), 1);
         assert_eq!(arm.get_mean_reward(), 5.0);
     }
 
@@ -111,7 +125,7 @@ mod tests {
         arm.pull(&mock_opti_function);
         arm.pull(&mock_opti_function);
 
-        assert_eq!(arm.get_num_pulls(), 2);
+        assert_eq!(arm.get_n_evaluations(), 2);
         assert_eq!(arm.get_mean_reward(), 5.0); // Since reward is always 5.0
     }
 
@@ -120,7 +134,7 @@ mod tests {
         let arm = Arm::new(&vec![1, 2]);
         let cloned_arm = arm.clone();
 
-        assert_eq!(arm.get_num_pulls(), cloned_arm.get_num_pulls());
+        assert_eq!(arm.get_n_evaluations(), cloned_arm.get_n_evaluations());
         assert_eq!(
             arm.get_function_value(&mock_opti_function),
             cloned_arm.get_function_value(&mock_opti_function)
@@ -145,7 +159,7 @@ mod tests {
         let mut arm = Arm::new(&vec![1, 2]);
         arm.pull(&mock_opti_function);
         let cloned_arm = arm.clone();
-        assert_eq!(arm.get_num_pulls(), cloned_arm.get_num_pulls());
+        assert_eq!(arm.get_n_evaluations(), cloned_arm.get_n_evaluations());
         assert_eq!(arm.get_mean_reward(), cloned_arm.get_mean_reward());
     }
 }

--- a/evobandits/src/evobandits.rs
+++ b/evobandits/src/evobandits.rs
@@ -55,8 +55,8 @@ impl EvoBandits {
     fn max_number_pulls(&self) -> i32 {
         let mut max_number_pulls = 0;
         for arm in &self.arm_memory {
-            if arm.get_num_pulls() > max_number_pulls {
-                max_number_pulls = arm.get_num_pulls();
+            if arm.get_n_evaluations() > max_number_pulls {
+                max_number_pulls = arm.get_n_evaluations();
             }
         }
         max_number_pulls
@@ -77,7 +77,7 @@ impl EvoBandits {
             );
 
             // checks if we are still in the non dominated-set (current mean <= mean_max_pulls)
-            if self.arm_memory[*arm_index as usize].get_num_pulls() == max_number_pulls {
+            if self.arm_memory[*arm_index as usize].get_n_evaluations() == max_number_pulls {
                 break;
             }
         }
@@ -96,7 +96,7 @@ impl EvoBandits {
                 (self.arm_memory[*arm_index as usize].get_mean_reward() - ucb_norm_min)
                     / (ucb_norm_max - ucb_norm_min);
             let penalty_term: f64 = (2.0 * (simulations_used as f64).ln()
-                / self.arm_memory[*arm_index as usize].get_num_pulls() as f64)
+                / self.arm_memory[*arm_index as usize].get_n_evaluations() as f64)
                 .sqrt();
             let ucb_value: f64 = transformed_sample_mean + penalty_term;
 
@@ -107,7 +107,7 @@ impl EvoBandits {
             }
 
             // checks if we are still in the non dominated-set (current mean <= mean_max_pulls)
-            if self.arm_memory[*arm_index as usize].get_num_pulls() == max_number_pulls {
+            if self.arm_memory[*arm_index as usize].get_n_evaluations() == max_number_pulls {
                 break;
             }
         }
@@ -282,7 +282,7 @@ impl EvoBandits {
                 // print number of pulls of best arm
                 println!(
                     " n(x): {}",
-                    self.arm_memory[best_arm_index as usize].get_num_pulls()
+                    self.arm_memory[best_arm_index as usize].get_n_evaluations()
                 );
             }
         }
@@ -429,7 +429,7 @@ mod tests {
 
         evobandits.sample_and_update(0, arm.clone(), &mock_opti_function);
 
-        assert_eq!(evobandits.arm_memory[0].get_num_pulls(), 2);
+        assert_eq!(evobandits.arm_memory[0].get_n_evaluations(), 2);
         assert_eq!(evobandits.arm_memory[0].get_mean_reward(), 0.0);
         assert_eq!(
             evobandits

--- a/examples/demo_EvoBandits.py
+++ b/examples/demo_EvoBandits.py
@@ -26,12 +26,10 @@ def rosenbrock_function(number: list):
 
 if __name__ == "__main__":
     bounds = [(-5, 10), (-5, 10)]
-    evaluation_budget = 10000
+    n_trials = 10000
     n_best = 3
     evobandits = EvoBandits()
-    best_arms = evobandits.optimize(
-        rosenbrock_function, bounds, evaluation_budget, n_best
-    )
+    best_arms = evobandits.optimize(rosenbrock_function, bounds, n_trials, n_best)
 
     print("Number of Results:", len(best_arms))  # matches n_best
     print(best_arms[0].to_dict)  # action_vector, value, and n_evaluations for best arm

--- a/examples/demo_EvoBandits.py
+++ b/examples/demo_EvoBandits.py
@@ -36,4 +36,4 @@ if __name__ == "__main__":
     print("Number of Results:", len(best_arms))  # matches n_best
     print(
         best_arms[0].to_dict
-    )  # action_vector, mean_reward, and num_pulls for best arm
+    )  # action_vector, mean_reward, and n_evaluations for best arm

--- a/examples/demo_EvoBandits.py
+++ b/examples/demo_EvoBandits.py
@@ -34,6 +34,4 @@ if __name__ == "__main__":
     )
 
     print("Number of Results:", len(best_arms))  # matches n_best
-    print(
-        best_arms[0].to_dict
-    )  # action_vector, mean_reward, and n_evaluations for best arm
+    print(best_arms[0].to_dict)  # action_vector, value, and n_evaluations for best arm

--- a/examples/demo_Study.py
+++ b/examples/demo_Study.py
@@ -38,4 +38,4 @@ if __name__ == "__main__":
     print("Number of Results:", len(results))  # matches n_best
     [
         print(r) for r in results
-    ]  # params, mean_reward, n_evaluations, and position for each result
+    ]  # params, value, n_evaluations, and position for each result

--- a/examples/demo_Study.py
+++ b/examples/demo_Study.py
@@ -38,4 +38,4 @@ if __name__ == "__main__":
     print("Number of Results:", len(results))  # matches n_best
     [
         print(r) for r in results
-    ]  # params, mean_reward, num_pulls, and position for each result
+    ]  # params, mean_reward, n_evaluations, and position for each result

--- a/py-evobandits/python/README.md
+++ b/py-evobandits/python/README.md
@@ -96,7 +96,7 @@ Internally, the method will store and transform the user inputs for rust-evoband
 and execute the set number of algorithm instances. Finally, it will also collect the results.
 
 ```python
-best_trial = study.optimize(objective, params, trials=10000, population_size=100, ...)
+best_trial = study.optimize(objective, params, n_trials=10000, population_size=100, ...)
 ```
 
 ## 4. Access the results (TBD.)

--- a/py-evobandits/python/evobandits/search.py
+++ b/py-evobandits/python/evobandits/search.py
@@ -1,3 +1,17 @@
+# Copyright 2025 EvoBandits
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 from sklearn.model_selection._search import BaseSearchCV
 
@@ -19,17 +33,17 @@ class EvoBanditsSearchCV(BaseSearchCV):
         pre_dispatch="2*n_jobs",
         error_score=np.nan,
         return_train_score=True,
-        evobandits_iterations=50,
+        n_trials=50,
     ):
         """
         param_distributions: dict
             Dictionary of parameter_name -> (lower_bound, upper_bound),
             all of which must be integer bounds.
-        evobandits_iterations: int
-            How many iterations (simulation budget) EvoBandits should run internally.
+        n_trials: int
+            How many trials (simulation budget) EvoBandits should run internally.
         """
         self.param_distributions = param_distributions
-        self.evobandits_iterations = evobandits_iterations
+        self.n_trials = n_trials
 
         super().__init__(
             estimator=estimator,
@@ -82,9 +96,7 @@ class EvoBanditsSearchCV(BaseSearchCV):
 
         # 3) Create the EvoBandits optimizer and search for the best param configuration
         evobandits_opt = EvoBandits()
-        best_action_vector = evobandits_opt.optimize(
-            evobandits_objective, bounds, self.evobandits_iterations
-        )
+        best_action_vector = evobandits_opt.optimize(evobandits_objective, bounds, self.n_trials)
 
         # 4) Evaluate the best param set again (so scikit-learn knows about it)
         best_dict = {}

--- a/py-evobandits/python/evobandits/study/study.py
+++ b/py-evobandits/python/evobandits/study/study.py
@@ -32,7 +32,7 @@ ALGORITHM_DEFAULT = EvoBandits()
 
 class Study:
     """
-    A Study represents an optimization task consisting of a set of trials.
+    A Study represents an optimization task.
 
     This class provides interfaces to optimize an objective function within specified bounds
     and to manage user-defined attributes related to the study.
@@ -106,7 +106,7 @@ class Study:
         self,
         objective: Callable,
         params: ParamsType,
-        trials: int,
+        n_trials: int,
         maximize: bool = False,
         n_best: int = 1,
     ) -> list[dict[str, Any]]:
@@ -119,7 +119,7 @@ class Study:
         Args:
             objective (Callable): The objective function to optimize.
             params (dict): A dictionary of parameters with their bounds.
-            trials (int): The number of trials to run.
+            n_trials (int): The number of evaluations to perform on the objective.
             maximize (bool): Indicates if objective is maximized. Default is False.
             n_best (int): The number of results to return per run. Default is 1.
 
@@ -134,7 +134,7 @@ class Study:
         self.params = params
 
         bounds = self._collect_bounds()
-        best_arms = self.algorithm.optimize(self._evaluate, bounds, trials, n_best, self.seed)
+        best_arms = self.algorithm.optimize(self._evaluate, bounds, n_trials, n_best, self.seed)
 
         best_results = []
         for i, arm in enumerate(best_arms, start=1):

--- a/py-evobandits/src/lib.rs
+++ b/py-evobandits/src/lib.rs
@@ -66,8 +66,8 @@ impl Arm {
     }
 
     #[getter]
-    fn mean_reward(&self) -> f64 {
-        self.arm.get_mean_reward()
+    fn value(&self) -> f64 {
+        self.arm.get_value()
     }
 
     #[getter]
@@ -80,8 +80,7 @@ impl Arm {
         let dict = PyDict::new(py);
         dict.set_item("action_vector", self.arm.get_action_vector().to_vec())
             .unwrap();
-        dict.set_item("mean_reward", self.arm.get_mean_reward())
-            .unwrap();
+        dict.set_item("value", self.arm.get_value()).unwrap();
         dict.set_item("n_evaluations", self.arm.get_n_evaluations())
             .unwrap();
         dict.into()

--- a/py-evobandits/src/lib.rs
+++ b/py-evobandits/src/lib.rs
@@ -130,7 +130,7 @@ impl EvoBandits {
     #[pyo3(signature = (
         py_func,
         bounds,
-        simulation_budget,
+        n_trials,
         n_best,
         seed=None,
     ))]
@@ -138,7 +138,7 @@ impl EvoBandits {
         &mut self,
         py_func: PyObject,
         bounds: Vec<(i32, i32)>,
-        simulation_budget: usize,
+        n_trials: usize,
         n_best: usize,
         seed: Option<u64>,
     ) -> PyResult<Vec<Arm>> {
@@ -146,7 +146,7 @@ impl EvoBandits {
 
         let result = panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.evobandits
-                .optimize(py_opti_function, bounds, simulation_budget, n_best, seed)
+                .optimize(py_opti_function, bounds, n_trials, n_best, seed)
         }));
 
         match result {

--- a/py-evobandits/src/lib.rs
+++ b/py-evobandits/src/lib.rs
@@ -61,8 +61,8 @@ impl Arm {
     }
 
     #[getter]
-    fn num_pulls(&self) -> i32 {
-        self.arm.get_num_pulls()
+    fn n_evaluations(&self) -> i32 {
+        self.arm.get_n_evaluations()
     }
 
     #[getter]
@@ -82,7 +82,7 @@ impl Arm {
             .unwrap();
         dict.set_item("mean_reward", self.arm.get_mean_reward())
             .unwrap();
-        dict.set_item("num_pulls", self.arm.get_num_pulls())
+        dict.set_item("n_evaluations", self.arm.get_n_evaluations())
             .unwrap();
         dict.into()
     }

--- a/py-evobandits/tests/_functions/clustering.py
+++ b/py-evobandits/tests/_functions/clustering.py
@@ -42,7 +42,7 @@ PARAMS = {
 TRIALS_EXAMPLE = [
     {
         "n_best": 1,
-        "mean_reward": 0.0,
+        "value": 0.0,
         "n_evaluations": 0,
         "params": {
             "algorithm": KMeans,
@@ -53,7 +53,7 @@ TRIALS_EXAMPLE = [
     },
     {
         "n_best": 2,
-        "mean_reward": 0.0,
+        "value": 0.0,
         "n_evaluations": 0,
         "params": {
             "algorithm": KMeans,

--- a/py-evobandits/tests/_functions/clustering.py
+++ b/py-evobandits/tests/_functions/clustering.py
@@ -43,7 +43,7 @@ TRIALS_EXAMPLE = [
     {
         "n_best": 1,
         "mean_reward": 0.0,
-        "num_pulls": 0,
+        "n_evaluations": 0,
         "params": {
             "algorithm": KMeans,
             "init": "k-means++",
@@ -54,7 +54,7 @@ TRIALS_EXAMPLE = [
     {
         "n_best": 2,
         "mean_reward": 0.0,
-        "num_pulls": 0,
+        "n_evaluations": 0,
         "params": {
             "algorithm": KMeans,
             "init": "k-means++",

--- a/py-evobandits/tests/_functions/rosenbrock.py
+++ b/py-evobandits/tests/_functions/rosenbrock.py
@@ -24,7 +24,7 @@ ARM_BEST = [Arm([1, 1])]
 
 # Params and expected result to mock a Study (two-dimensional, with n_best = 1)
 PARAMS = {"number": IntParam(-5, 10, 2)}
-TRIAL_BEST = [{"n_best": 1, "mean_reward": 0.0, "num_pulls": 0, "params": {"number": [1, 1]}}]
+TRIAL_BEST = [{"n_best": 1, "mean_reward": 0.0, "n_evaluations": 0, "params": {"number": [1, 1]}}]
 
 
 def function(number: list):

--- a/py-evobandits/tests/_functions/rosenbrock.py
+++ b/py-evobandits/tests/_functions/rosenbrock.py
@@ -24,7 +24,7 @@ ARM_BEST = [Arm([1, 1])]
 
 # Params and expected result to mock a Study (two-dimensional, with n_best = 1)
 PARAMS = {"number": IntParam(-5, 10, 2)}
-TRIAL_BEST = [{"n_best": 1, "mean_reward": 0.0, "n_evaluations": 0, "params": {"number": [1, 1]}}]
+TRIAL_BEST = [{"n_best": 1, "value": 0.0, "n_evaluations": 0, "params": {"number": [1, 1]}}]
 
 
 def function(number: list):

--- a/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
+++ b/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
@@ -22,12 +22,12 @@ from tests._functions import rosenbrock as rb
 
 def test_arm():
     mock_av = [1, 1, 1]
-    exp_dict = {"action_vector": mock_av, "mean_reward": 0.0, "n_evaluations": 0}
+    exp_dict = {"action_vector": mock_av, "value": 0.0, "n_evaluations": 0}
 
     arm = Arm(mock_av)
     assert arm.action_vector == mock_av
     assert arm.n_evaluations == 0
-    assert arm.mean_reward == 0.0
+    assert arm.value == 0.0
     assert arm.to_dict == exp_dict
 
 

--- a/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
+++ b/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
@@ -56,7 +56,7 @@ def test_evobandits_init(kwargs):
 
 
 @pytest.mark.parametrize(
-    "bounds, budget, kwargs",
+    "bounds, n_trials, kwargs",
     [
         [[(0, 100), (0, 100)] * 5, 100, {}],
         [[(0, 100), (0, 100)] * 5, 100, {"seed": 42}],
@@ -73,7 +73,7 @@ def test_evobandits_init(kwargs):
         "success",
         "success_with_seed",
         "success_with_n_best",
-        "fail_budget_value",
+        "fail_n_trials_value",
         "fail_n_best_value",
         "fail_population_size_value",  # ToDo Issue #57: Err should be raised in the constructor
         "fail_mutation_rate_value",  # ToDo Issue #57: Err should be raised in the constructor
@@ -82,13 +82,13 @@ def test_evobandits_init(kwargs):
         "fail_population_size_solution_size",
     ],
 )
-def test_evobandits(bounds, budget, kwargs):
+def test_evobandits(bounds, n_trials, kwargs):
     expectation = kwargs.pop("exp", nullcontext())
     seed = kwargs.pop("seed", None)
     n_best = kwargs.pop("n_best", 1)
     with expectation:
         evobandits = EvoBandits(**kwargs)
-        result = evobandits.optimize(rb.function, bounds, budget, n_best, seed)
+        result = evobandits.optimize(rb.function, bounds, n_trials, n_best, seed)
 
         assert all(isinstance(r, Arm) for r in result)
         assert len(result) == n_best

--- a/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
+++ b/py-evobandits/tests/evobandits_rs_tests/test_rs_evobandits.py
@@ -22,11 +22,11 @@ from tests._functions import rosenbrock as rb
 
 def test_arm():
     mock_av = [1, 1, 1]
-    exp_dict = {"action_vector": mock_av, "mean_reward": 0.0, "num_pulls": 0}
+    exp_dict = {"action_vector": mock_av, "mean_reward": 0.0, "n_evaluations": 0}
 
     arm = Arm(mock_av)
     assert arm.action_vector == mock_av
-    assert arm.num_pulls == 0
+    assert arm.n_evaluations == 0
     assert arm.mean_reward == 0.0
     assert arm.to_dict == exp_dict
 

--- a/py-evobandits/tests/study_tests/test_study.py
+++ b/py-evobandits/tests/study_tests/test_study.py
@@ -62,7 +62,7 @@ def test_study_init(seed, kwargs, exp_algorithm, caplog):
 
 
 @pytest.mark.parametrize(
-    "objective, params, trials, kwargs",
+    "objective, params, n_trials, kwargs",
     [
         [rb.function, rb.PARAMS, 1, {}],
         [
@@ -81,7 +81,7 @@ def test_study_init(seed, kwargs, exp_algorithm, caplog):
         "invalid_maximize_type",
     ],
 )
-def test_optimize(objective, params, trials, kwargs):
+def test_optimize(objective, params, n_trials, kwargs):
     # Mock dependencies
     # Per default, and expected results from the rosenbrock testcase are used to mock EvoBandits.
     mock_algorithm = MagicMock()
@@ -94,6 +94,6 @@ def test_optimize(objective, params, trials, kwargs):
 
     # Optimize a study and verify results
     with expectation:
-        result = study.optimize(objective, params, trials, **kwargs)
+        result = study.optimize(objective, params, n_trials, **kwargs)
         assert result == exp_result
         assert mock_algorithm.optimize.call_count == 1  # Always run algorithm once for now


### PR DESCRIPTION
Aims to close #105 by renaming variables, ensuring consistency over all modules. Adapted the glossary accordingly.

Example Output after modifications.

```plaintext
PS C:\Users\fwuer\Code\EvoBandits> & c:/Users/fwuer/Code/EvoBandits/.venv/Scripts/python.exe c:/Users/fwuer/Code/EvoBandits/examples/demo_Study.py
Number of Results: 3
{'value': 0.0, 'n_evaluations': 82, 'params': {'number': [1, 1]}, 'n_best': 1}
{'value': 1.0, 'n_evaluations': 86, 'params': {'number': [0, 0]}, 'n_best': 2}
{'value': 1.0, 'n_evaluations': 85, 'params': {'number': [2, 4]}, 'n_best': 3}
```