### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/EvoBandits/EvoBandits/security/code-scanning/2](https://github.com/EvoBandits/EvoBandits/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `build` job, specifying `contents: read` as the minimal required permission. This ensures the `build` job has only the permissions necessary to perform its tasks, adhering to the principle of least privilege. The `deploy` job already has a `permissions` block, so no changes are needed there.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
