### PR TITLE
Consistent Typehints

### DIFF
--- a/py-evobandits/python/evobandits/params/README.md
+++ b/py-evobandits/python/evobandits/params/README.md
@@ -49,7 +49,7 @@ BaseParam
 # Definition of parameters (User):
 params = {
    "a": IntParam(low=0, high=1000, size=10)
-   "b": FloatParam(low=0, high=1, nsteps=100, log=True)
+   "b": FloatParam(low=0, high=1, n_steps=100, log=True)
    "c": CategoricalParam(['balanced', 'None']) # Future work
 }
 

--- a/py-evobandits/python/evobandits/params/base_param.py
+++ b/py-evobandits/python/evobandits/params/base_param.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 
 class BaseParam(ABC):
@@ -26,12 +27,12 @@ class BaseParam(ABC):
     The `size` attribute determines the dimensionality of the parameter.
     """
 
-    def __init__(self, size: int = 1):
+    def __init__(self, size: int = 1) -> None:
         """
         Initializes a BaseParam instance.
 
         Args:
-            size (int): The size of the parameter if it is a list. This determines
+            The size of the parameter if it is a list. This determines
             the number of dimensions for the parameter. Defaults to 1.
 
         Raises:
@@ -43,7 +44,7 @@ class BaseParam(ABC):
 
     @property
     @abstractmethod
-    def bounds(self) -> list[tuple]:
+    def bounds(self) -> list[tuple[int, int]]:
         """
         Abstract property to calculate and return the parameter's internal bounds.
 
@@ -53,7 +54,7 @@ class BaseParam(ABC):
         taking into account the `size`.
 
         Returns:
-            list[tuple]: A list of tuples representing the bounds, where each tuple
+            A list of tuples representing the bounds, where each tuple
             contains the lower and upper bounds for a dimension. The length of the
             list should match the `size`.
 
@@ -61,7 +62,7 @@ class BaseParam(ABC):
         raise NotImplementedError("Subclasses must implement the 'bounds' property.")
 
     @abstractmethod
-    def decode(self, actions: list[int]) -> bool | int | str | float | list:
+    def decode(self, actions: list[int]) -> bool | int | str | float | Callable | None | list:
         """
         Abstract method to decode optimization actions as parameter values.
 
@@ -70,12 +71,11 @@ class BaseParam(ABC):
         specific mapping logic, considering the `size`.
 
         Args:
-            actions (list[int]): A list of integers representing actions from the
+            actions: A list of integers representing actions from the
             optimization algorithm. The length of this list should match the `size`.
 
         Returns:
-            bool | int | str | float | list: The resulting parameter value(s)
-            corresponding to the given actions.
-
+            The resulting parameter value(s) corresponding to the given actions.
+            Returns the value directly in case of `self.size` equals 1, a list of values else.
         """
         raise NotImplementedError("Subclasses must implement the 'map_to_value' method.")

--- a/py-evobandits/python/evobandits/params/categorical_param.py
+++ b/py-evobandits/python/evobandits/params/categorical_param.py
@@ -24,15 +24,12 @@ class CategoricalParam(BaseParam):
     A class representing a categorical parameter.
     """
 
-    def __init__(self, choices: list[ChoiceType]):
+    def __init__(self, choices: list[ChoiceType]) -> None:
         """
         Creates a CategoricalParam that will suggest one of the choices during optimization.
 
         Args:
-            choices (list[ChoiceType]): A list of possible choices for the parameter.
-
-        Returns:
-            CategoricalParam: An instance of the parameter with the specified properties.
+            choices: A list of possible choices for the parameter.
 
         Raises:
             ValueError: Raises a ValueError if choices is not a list, or if the objects in the list
@@ -55,11 +52,11 @@ class CategoricalParam(BaseParam):
         super().__init__(size=1)
         self.choices: list[ChoiceType] = choices
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"CategoricalParam(choices={self.choices})"
 
     @property
-    def bounds(self) -> list[tuple]:
+    def bounds(self) -> list[tuple[int, int]]:
         """
         Calculates and returns the parameter's internal bounds for optimization.
 
@@ -67,7 +64,7 @@ class CategoricalParam(BaseParam):
         of the optimization algorithm regarding the parameter's value.
 
         Returns:
-            list[tuple]: A list of tuples representing the bounds.
+            A list of (lower_bound, upper_bound) tuples representing the bounds.
         """
         return [(0, len(self.choices) - 1)]
 
@@ -81,8 +78,8 @@ class CategoricalParam(BaseParam):
         Returns:
             ChoiceType | list[ChoiceType]: The resulting choice(s).
         """
-        actions = [self.choices[idx] for idx in actions]
+        values: list[ChoiceType] = [self.choices[idx] for idx in actions]
 
-        if len(actions) == 1:
-            return actions[0]
-        return actions
+        if len(values) == 1:
+            return values[0]
+        return values

--- a/py-evobandits/python/evobandits/params/categorical_param.py
+++ b/py-evobandits/python/evobandits/params/categorical_param.py
@@ -73,10 +73,10 @@ class CategoricalParam(BaseParam):
         Decodes an action from the optimization problem to the value of the parameter.
 
         Args:
-            actions (list[int]): A list of integers to map.
+            actions: A list of integers to map.
 
         Returns:
-            ChoiceType | list[ChoiceType]: The resulting choice(s).
+            The resulting choice(s).
         """
         values: list[ChoiceType] = [self.choices[idx] for idx in actions]
 

--- a/py-evobandits/python/evobandits/params/float_param.py
+++ b/py-evobandits/python/evobandits/params/float_param.py
@@ -89,7 +89,7 @@ class FloatParam(BaseParam):
         of the optimization algorithm about the parameter's value
 
         Returns:
-            list[tuple]: A list of tuples representing the bounds
+            A list of tuples representing the bounds
         """
         return [(0, self.n_steps)] * self.size
 
@@ -98,10 +98,10 @@ class FloatParam(BaseParam):
         Decodes an action by the optimization problem to the value of the parameter.
 
         Args:
-            actions (list[int]): A list of integer to map.
+            A list of integer to map.
 
         Returns:
-            float | list[float]: The resulting float value(s).
+            The resulting float value(s).
         """
         # Apply scaling
         values = [self._low_trans + self._step_size * x for x in actions]

--- a/py-evobandits/python/evobandits/params/float_param.py
+++ b/py-evobandits/python/evobandits/params/float_param.py
@@ -23,21 +23,21 @@ class FloatParam(BaseParam):
     """
 
     def __init__(
-        self, low: float, high: float, size: int = 1, nsteps: float = 100, log: bool = False
-    ):
+        self, low: float, high: float, size: int = 1, n_steps: float = 100, log: bool = False
+    ) -> None:
         """
         Creates a FloatParam that will suggest float values during the optimization.
 
         The parameter can either be a float, or a list of floats, depending on the specified
-        size. The values sampled by the optimizaton will be limited to the specified granularity,
+        size. The values sampled by the optimization will be limited to the specified granularity,
         lower and upper bounds.
 
         Args:
-            low (float): The lower bound of the suggested values.
-            high (float): The upper bound of the suggested values.
-            size (int): The size if the parameter shall be a list of floats. Default is 1.
-            nsteps (int): The number of steps between low and high. Default is 100.
-            log (bool): A flag to indicate log-transformation. Default is False.
+            low: The lower bound of the suggested values.
+            high: The upper bound of the suggested values.
+            size: The size if the parameter shall be a list of floats. Default is 1.
+            n_steps: The number of steps between low and high. Default is 100.
+            log: A flag to indicate log-transformation. Default is False.
 
         Returns:
             FloatParam: An instance of the parameter with the specified properties.
@@ -47,13 +47,13 @@ class FloatParam(BaseParam):
             low, or if size is not a positive integer, or if step is not a positive float.
 
         Example:
-        >>> param = FloatParam(low=1.0, high=10.0, size=3, nsteps=100)
+        >>> param = FloatParam(low=1.0, high=10.0, size=3, n_steps=100)
         >>> print(param)
-        FloatParam(low=1.0, high=10.0, size=3, nsteps=100)
+        FloatParam(low=1.0, high=10.0, size=3, n_steps=100)
         """
         if high <= low:
             raise ValueError("high must be a float that is greater than low.")
-        if nsteps <= 0:
+        if n_steps <= 0:
             raise ValueError("steps must be positive integer.")
         if log and low <= 0.0:
             raise ValueError("low must be greater than 0 for a log-transformation.")
@@ -62,26 +62,26 @@ class FloatParam(BaseParam):
         self.log: bool = bool(log)
         self.low: float = float(low)
         self.high: float = float(high)
-        self.nsteps: int = int(nsteps)
+        self.n_steps: int = int(n_steps)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr = f"FloatParam(low={self.low}, high={self.high}, size={self.size}, "
-        repr += f"nsteps={self.nsteps}, log={self.log})"
+        repr += f"n_steps={self.n_steps}, log={self.log})"
         return repr
 
     @property
-    def _low_trans(self):
+    def _low_trans(self) -> float:
         if self.log:
             return math.log(self.low)
         return self.low
 
     @property
-    def _stepsize(self):
+    def _step_size(self) -> float:
         high_trans = math.log(self.high) if self.log else self.high
-        return (high_trans - self._low_trans) / self.nsteps
+        return (high_trans - self._low_trans) / self.n_steps
 
     @property
-    def bounds(self) -> list[tuple]:
+    def bounds(self) -> list[tuple[int, int]]:
         """
         Calculate and return the parameter's internal bounds for the optimization.
 
@@ -91,7 +91,7 @@ class FloatParam(BaseParam):
         Returns:
             list[tuple]: A list of tuples representing the bounds
         """
-        return [(0, self.nsteps)] * self.size
+        return [(0, self.n_steps)] * self.size
 
     def decode(self, actions: list[int]) -> float | list[float]:
         """
@@ -104,12 +104,12 @@ class FloatParam(BaseParam):
             float | list[float]: The resulting float value(s).
         """
         # Apply scaling
-        actions = [self._low_trans + self._stepsize * x for x in actions]
+        values = [self._low_trans + self._step_size * x for x in actions]
 
         # Optional log-transformation
         if self.log:
-            actions = [math.exp(x) for x in actions]
+            values = [math.exp(x) for x in values]
 
-        if len(actions) == 1:
-            return actions[0]
-        return actions
+        if len(values) == 1:
+            return values[0]
+        return values

--- a/py-evobandits/python/evobandits/params/int_param.py
+++ b/py-evobandits/python/evobandits/params/int_param.py
@@ -21,7 +21,7 @@ class IntParam(BaseParam):
     A class representing an integer parameter.
     """
 
-    def __init__(self, low: int, high: int, size: int = 1):
+    def __init__(self, low: int, high: int, size: int = 1) -> None:
         """
         Creates an IntParam that will suggest integer values during the optimization.
 
@@ -30,9 +30,9 @@ class IntParam(BaseParam):
         lower and upper bounds.
 
         Args:
-            low (int): The lower bound of the suggested values.
-            high (int): The upper bound of the suggested values.
-            size (int): The size if the parameter shall be a list of integers. Default is 1.
+            low: The lower bound of the suggested values.
+            high: The upper bound of the suggested values.
+            size: The size if the parameter shall be a list of integers. Default is 1.
 
         Returns:
             IntParam: An instance of the parameter with the specified properties.
@@ -53,11 +53,11 @@ class IntParam(BaseParam):
         self.low: int = int(low)
         self.high: int = int(high)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"IntParam(low={self.low}, high={self.high}, size={self.size})"
 
     @property
-    def bounds(self) -> list[tuple]:
+    def bounds(self) -> list[tuple[int, int]]:
         """
         Calculate and return the parameter's internal bounds for the optimization.
 
@@ -65,8 +65,7 @@ class IntParam(BaseParam):
         of the optimization algorithm about the parameter's value.
 
         Returns:
-            list[tuple]: A list of tuples representing the bounds.
-
+            A list of tuples representing the bounds.
         """
         return [(self.low, self.high)] * self.size
 
@@ -75,10 +74,10 @@ class IntParam(BaseParam):
         Decode an action by the optimization problem to the value of the parameter.
 
         Args:
-            actions (list[int]): A list of integers to map.
+            actions: A list of integers to map.
 
         Returns:
-            int | list[int]: The resulting integer value(s).
+            The resulting integer value(s).
         """
         if len(actions) == 1:
             return actions[0]

--- a/py-evobandits/python/evobandits/study/study.py
+++ b/py-evobandits/python/evobandits/study/study.py
@@ -39,12 +39,12 @@ class Study:
     and to manage user-defined attributes related to the study.
     """
 
-    def __init__(self, seed: int | None = None, algorithm=ALGORITHM_DEFAULT) -> None:
+    def __init__(self, seed: int | None = None, algorithm: EvoBandits = ALGORITHM_DEFAULT) -> None:
         """
-        Initialize a Study instance.
+        Initializes a Study instance.
 
         Args:
-            seed: The seed for the Study. Defaults to None (use system entropy).
+            seed: The seed for the Study. Defaults to None (uses system entropy).
             algorithm: The optimization algorithm to use. Defaults to EvoBandits.
         """
         if seed is None:
@@ -53,9 +53,9 @@ class Study:
             raise TypeError(f"Seed must be integer: {seed}")
 
         self.seed: int | None = seed
-        self.algorithm = algorithm  # ToDo Issue #23: type and input validation
-        self.objective: Callable | None = None  # ToDo Issue #23: type and input validation
-        self.params: ParamsType | None = None  # ToDo Issue #23: Input validation
+        self.algorithm: EvoBandits = algorithm
+        self.objective: Callable | None = None  # type: ignore
+        self.params: ParamsType | None = None  # type: ignore
         self.results: list[dict[str, Any]] = []
 
         # 1 for minimization, -1 for maximization to avoid repeated branching during optimization.
@@ -63,25 +63,25 @@ class Study:
 
     def _collect_bounds(self) -> list[tuple[int, int]]:
         """
-        Collects the bounds of all parameters in the study.
+        Collects the bounds of the parameter configuration saved to `self.params`.
 
         Returns:
-            list[tuple[int, int]]: A list of tuples representing the bounds for each parameter.
+            The bounds, a list of (lower_bound, upper_bound) tuples for all parameters.
         """
         bounds = []
         for param in self.params.values():
             bounds.extend(param.bounds)
         return bounds
 
-    def _decode(self, action_vector: list) -> dict:
+    def _decode(self, action_vector: list[int]) -> dict[str, Any]:
         """
-        Decodes an action vector to a dictionary that contains the solution for each parameter.
+        Decodes an action vector into a dictionary mapping parameter names to their decoded values.
 
         Args:
-            action_vector (list): A list of actions to map.
+            action_vector: The encoded representation of parameter values.
 
         Returns:
-            dict: The distinct solution for the action vector, formatted as dictionary.
+            A dictionary of parameter names and their decoded values.
         """
         result = {}
         idx = 0
@@ -90,15 +90,15 @@ class Study:
             idx += param.size
         return result
 
-    def _evaluate(self, action_vector: list) -> float:
+    def _evaluate(self, action_vector: list[int]) -> float:
         """
         Execute a trial with the given action vector.
 
         Args:
-            action_vector (list): A list of actions to execute.
+            action_vector: The encoded representation of parameter values.
 
         Returns:
-            float: The result of the objective function.
+            The value from a single evaluation of the objective function.
         """
         solution = self._decode(action_vector)
         evaluation = self._direction * self.objective(**solution)
@@ -120,12 +120,12 @@ class Study:
         specified bounds and running the objective function for a given number of trials.
 
         Args:
-            objective (Callable): The objective function to optimize.
-            params (dict): A dictionary of parameters with their bounds.
-            n_trials (int): The number of evaluations to perform on the objective.
-            maximize (bool): Indicates if objective is maximized. Default is False.
-            n_best (int): The number of results to return per run. Default is 1.
-            n_runs (int): The number of times optimization is repeated. Default is 1.
+            objective: The objective function to optimize.
+            params: A dictionary of parameters with their bounds.
+            n_trials: The number of evaluations to perform on the objective.
+            maximize: Indicates if objective is maximized. Default is False.
+            n_best: The number of results to return per run. Default is 1.
+            n_runs: The number of times optimization is repeated. Default is 1.
         """
         if not isinstance(maximize, bool):
             raise TypeError(f"maximize must be a bool, got {type(maximize)}.")
@@ -136,8 +136,8 @@ class Study:
         if n_runs < 1:
             raise ValueError(f"n_runs must be an int larger than 0, got {n_runs}.")
 
-        self.objective = objective
-        self.params = params
+        self.objective: Callable = objective
+        self.params: ParamsType = params
         bounds = self._collect_bounds()
 
         for run_id in range(n_runs):
@@ -159,7 +159,7 @@ class Study:
         Returns the best value found during optimization.
 
         Returns:
-            float: The best value among `study.results`.
+            The best value among `study.results`.
         """
         if not self.results:
             raise AttributeError("Study has no results. Run study.optimize() first.")
@@ -171,7 +171,7 @@ class Study:
         Returns the mean value of all results found during optimization.
 
         Returns:
-            float: The mean value of `study.results`.
+            The mean value of `study.results`.
         """
         if not self.results:
             raise AttributeError("Study has no results. Run study.optimize() first.")
@@ -183,18 +183,18 @@ class Study:
         Returns the best solution found during optimization.
 
         Returns:
-            dict[str, Any]: The solution (as a dictionary) that yielded `study.best_value`.
+            The solution (as a dictionary) that yielded `study.best_value`.
         """
         if not self.results:
             raise AttributeError("Study has no results. Run study.optimize() first.")
         return next(r for r in self.results if r["value"] == self.best_value)
 
     @property
-    def best_params(self) -> ParamsType:
+    def best_params(self) -> dict[str, Any]:
         """
         Returns the parameter set corresponding to the best value found during optimization.
 
         Returns:
-            ParamsType: The parameters (as a dictionary) that yielded `study.best_value`.
+            The parameters (as a dictionary) that yielded `study.best_value`.
         """
         return self.best_solution["params"]

--- a/py-evobandits/tests/param_tests/test_float_param.py
+++ b/py-evobandits/tests/param_tests/test_float_param.py
@@ -1,3 +1,17 @@
+# Copyright 2025 EvoBandits
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from contextlib import nullcontext
 
 import pytest
@@ -6,11 +20,11 @@ from evobandits.params import FloatParam
 test_float_param_new_data = [
     pytest.param(0, 1, {}, [(0, 100)], id="base"),
     pytest.param(0, 1, {"size": 2}, [(0, 100), (0, 100)], id="vector"),
-    pytest.param(0, 1, {"nsteps": 10}, [(0, 10)], id="nsteps"),
+    pytest.param(0, 1, {"n_steps": 10}, [(0, 10)], id="n_steps"),
     pytest.param(1, 2, {"log": True}, [(0, 100)], id="log"),
     pytest.param(0, 0, {"exp": pytest.raises(ValueError)}, None, id="high_value"),
     pytest.param(0, 1, {"size": 0, "exp": pytest.raises(ValueError)}, None, id="size_value"),
-    pytest.param(0, 1, {"nsteps": 0, "exp": pytest.raises(ValueError)}, None, id="nsteps_value"),
+    pytest.param(0, 1, {"n_steps": 0, "exp": pytest.raises(ValueError)}, None, id="n_steps_value"),
     pytest.param(0, 1, {"log": True, "exp": pytest.raises(ValueError)}, None, id="log_value"),
 ]
 
@@ -38,7 +52,7 @@ def test_float_param_new(low, high, kwargs, exp_bounds):
 test_float_param_mapping_data = [
     pytest.param(FloatParam(0, 1), 5, 0.05, id="base"),
     pytest.param(FloatParam(0.123, 4.567), 100, 4.567, id="modify_range"),
-    pytest.param(FloatParam(0, 1, nsteps=1000), 5, 0.005, id="modify_steps"),
+    pytest.param(FloatParam(0, 1, n_steps=1000), 5, 0.005, id="modify_steps"),
     pytest.param(FloatParam(1, 2, log=True), 100, 2.000, id="log_transform"),
 ]
 

--- a/py-evobandits/tests/study_tests/test_study.py
+++ b/py-evobandits/tests/study_tests/test_study.py
@@ -51,8 +51,6 @@ def test_study_init(seed, kwargs, exp_algorithm, caplog):
 
         assert study.seed == seed
         assert study.algorithm == exp_algorithm
-        assert study.objective is None
-        assert study.params is None
 
         if log:
             level, msg = log
@@ -99,6 +97,9 @@ def test_study_init(seed, kwargs, exp_algorithm, caplog):
                 ],
             },
         ],
+        [rb.function, ["number"], 1, {"exp": pytest.raises(TypeError)}],
+        [rb.function, {1: "number"}, 1, {"exp": pytest.raises(TypeError)}],
+        [rb.function, {"number": "BaseParam"}, 1, {"exp": pytest.raises(TypeError)}],
         [rb.function, rb.PARAMS, 1, {"maximize": "False", "exp": pytest.raises(TypeError)}],
         [rb.function, rb.PARAMS, 1, {"n_runs": "2", "exp": pytest.raises(TypeError)}],
         [rb.function, rb.PARAMS, 1, {"n_runs": 0, "exp": pytest.raises(ValueError)}],
@@ -108,6 +109,9 @@ def test_study_init(seed, kwargs, exp_algorithm, caplog):
         "valid_clustering_testcase",
         "default_with_maximize",
         "default_with_n_runs",
+        "invalid_params_not_a_mapping",
+        "invalid_params_not_a_str_key",
+        "invalid_params_not_a_BaseParam_value",
         "invalid_maximize_type",
         "invalid_n_runs_type",
         "invalid_n_runs_value",

--- a/py-evobandits/tests/study_tests/test_study_internals.py
+++ b/py-evobandits/tests/study_tests/test_study_internals.py
@@ -1,3 +1,17 @@
+# Copyright 2025 EvoBandits
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 from evobandits import CategoricalParam, IntParam
 from evobandits.study.study import Study
@@ -19,7 +33,7 @@ from evobandits.study.study import Study
 def test_collect_bounds(params, exp_bounds):
     # Mock or patch dependencies
     study = Study(seed=42)  # with seed to avoid warning logs
-    study.params = params
+    study._params = params
 
     # Collect bounds and verify result
     bounds = study._collect_bounds()
@@ -46,7 +60,7 @@ def test_collect_bounds(params, exp_bounds):
 def test_decode(params, action_vector, exp_solution):
     # Mock or patch dependencies
     study = Study(seed=42)  # with seed to avoid warning logs
-    study.params = params
+    study._params = params
 
     # Decode an action vector and verify result
     solution = study._decode(action_vector)
@@ -72,8 +86,8 @@ def test_evaluate(params, action_vector, exp_result, kwargs):
         return sum(a) * 0.5 if b else -sum(a) * 0.5
 
     study = Study(seed=42)  # with seed to avoid warning logs
-    study.params = params
-    study.objective = dummy_objective
+    study._params = params
+    study._objective = dummy_objective
     study._direction = kwargs.get("_direction", 1)
 
     # Verify if study evaluates the objective


### PR DESCRIPTION
Modifications to typehints and docstrings that work towards closing #23: 

* Added missing typehints, or modified inconsistent ones. 
* Added input validation for `study._params`.
* Removed typehints from the docstrings, as this causes duplicates in the docs, as mkdocs parses the typehints as well. (image below).
* For consistency with `n_trials`, `n_evaluations` etc., renamed `nsteps` -> `n_steps`


![image](https://github.com/user-attachments/assets/554c2221-fb15-4a7b-b113-a6d0f3d075f6)
