### PR TITLE
32 doc segment on seeding and reproduction of results

### DIFF
--- a/docs/source/tutorials/efficient_objective_function.md
+++ b/docs/source/tutorials/efficient_objective_function.md
@@ -1,6 +1,8 @@
 ## Summary
 The simulation of the objective function is often the most demanding part of an experiment, especially when simulating with an efficient optimizer. This guide demonstrates how to accelerate simulation with EvoBandits using [`Numba`](https://numba.pydata.org/), an open source JIT compiler, using a simple example.
 
+---
+
 ## Efficient Objective Function
 The example optimizes the configuration of a simple test function, which is referred to as Test Problem 4 (TP4) and explained in detail in the [GMAB Paper](https://ieeexplore.ieee.org/document/10818791) by Preil & Krapp (2025). With regard to the numba acceleration, it can be seen as a lightweight example representing more complex objectives that might leverage full Numba capabilities such as parallelization or GPU acceleration.
 
@@ -14,7 +16,7 @@ def tp4_func(action_vector: np.ndarray, seed: int = -1) -> float:
     return res
 ```
 
-!!! note "Seeding with numba"
+!!! note "Reproducibility with numba"
 
     Since numba-compiled functions cannot use a global RNG seed at this time, the optimizer must generate and pass a new seed for each evaluation of the objective if results shall be reproduced:
 
@@ -49,6 +51,8 @@ EvoBandits treats Numba-compiled and pure Python functions equivalently. For det
     Best configuration:  {'action_vector': [54, 55, 57, 57, 57]}
     ```
 
+---
+
 ## References
 
 ```
@@ -56,17 +60,17 @@ Preil, D., & Krapp, M. (2024). Genetic Multi-Armed Bandits: A Reinforcement Lear
 ```
 
 ## Try it yourself!
-You can find the full example in the `evobandits.examples` module, available on [GitHub](https://github.com/EvoBandits/EvoBandits/blob/main/examples/efficient_objective_function.py).
+You can find the full example in the `evobandits.examples` module, available on [GitHub](https://github.com/EvoBandits/EvoBandits/blob/main/examples/demo_Study.py).
 
 !!! note
 
-    Running the examples requires additional dependencies, such as Numba and NumPy, which can be installed using:
+    Running the examples requires additional dependencies, such NumPy, which can be installed using:
 
     ```bash
     pip install evobandits[examples]
     ```
 
-??? quote "Expand to copy `examples/efficient\_objective\_function.py`"
+??? quote "Expand to copy `examples/demo\Study.py`"
 
     ```python
     --8<-- "examples/efficient_objective_function.py"

--- a/docs/source/tutorials/efficient_objective_function.md
+++ b/docs/source/tutorials/efficient_objective_function.md
@@ -64,7 +64,7 @@ You can find the full example in the `evobandits.examples` module, available on 
 
 !!! note
 
-    Running the examples requires additional dependencies, such NumPy, which can be installed using:
+    Running the examples requires additional dependencies, such as Numba and NumPy, which can be installed using:
 
     ```bash
     pip install evobandits[examples]

--- a/docs/source/tutorials/efficient_objective_function.md
+++ b/docs/source/tutorials/efficient_objective_function.md
@@ -14,36 +14,40 @@ def tp4_func(action_vector: np.ndarray, seed: int = -1) -> float:
     return res
 ```
 
-## Reproducibility of Results
-Since numba-compiled functions cannot use a global RNG seed at this time, the optimizer must generate and pass a new seed for each evaluation of the objective if results shall be reproduced:
+!!! note "Seeding with numba"
 
-* As shown above, `tp4_func` must accept a parameter `seed`. In this instance, a sentinel value of `-1` is used instead of `None` to denote an unseeded run, as this avoids a more complex and explicit numba setup that handles an optional function argument.
-* A seed must be passed to the `Study` on initialization to set up a seeded experiment. The Study will then automatically generate an independent seed from the range of non-negative integers for each evaluation and pass it to `tp4_func`.
+    Since numba-compiled functions cannot use a global RNG seed at this time, the optimizer must generate and pass a new seed for each evaluation of the objective if results shall be reproduced:
+
+    * As shown above, `tp4_func` must accept a parameter `seed`. In this instance, a sentinel value of `-1` is used instead of `None` to denote an unseeded run, as this avoids a more complex and explicit numba setup that handles an optional function argument.
+    * A seed must be passed to the `Study` on initialization to set up a seeded experiment. The Study will then automatically generate an independent seed from the range of non-negative integers for each evaluation and pass it to `tp4_func`.
 
 ## Simulation
 EvoBandits treats Numba-compiled and pure Python functions equivalently. For details on the configuration and execution of the optimization, please refer to the Reference and other examples on this page.
 
-```python
-if __name__ == "__main__":
-    # Model a five-dimensional instance of TP4.
-    params = {"action_vector": IntParam(-100, 100, 5)}
-    n_trials = 20_000
-    n_runs = 10
+=== "Code"
 
-    # Execute optimization
-    study = Study(seed=42)
-    study.optimize(tp4_func, params, n_trials, n_runs=n_runs)
-    print("Best solution found during optimization: ", study.best_value)
-    print("Mean result:", study.mean_value)
-    print("Best configuration: ", study.best_params)
-```
+    ```python
+    if __name__ == "__main__":
+        # Model a five-dimensional instance of TP4.
+        params = {"action_vector": IntParam(-100, 100, 5)}
+        n_trials = 20_000
+        n_runs = 10
 
-Example Output:
-```
-Best solution found during optimization:  -2548.569595505386
-Mean result: -2449.193337282534
-Best configuration:  {'action_vector': [54, 55, 57, 57, 57]}
-```
+        # Execute optimization
+        study = Study(seed=42)
+        study.optimize(tp4_func, params, n_trials, n_runs=n_runs)
+        print("Best solution found during optimization: ", study.best_value)
+        print("Mean result:", study.mean_value)
+        print("Best configuration: ", study.best_params)
+    ```
+
+=== "Example Output"
+
+    ```
+    Best solution found during optimization:  -2548.569595505386
+    Mean result: -2449.193337282534
+    Best configuration:  {'action_vector': [54, 55, 57, 57, 57]}
+    ```
 
 ## References
 
@@ -52,10 +56,18 @@ Preil, D., & Krapp, M. (2024). Genetic Multi-Armed Bandits: A Reinforcement Lear
 ```
 
 ## Try it yourself!
-The complete example is available on [Github](https://github.com/EvoBandits/EvoBandits/blob/main/examples/efficient_objective_function.py). Running it requires additional dependencies, which can be installed using:
+You can find the full example in the `evobandits.examples` module, available on [GitHub](https://github.com/EvoBandits/EvoBandits/blob/main/examples/efficient_objective_function.py).
 
-```bash
-pip install evobandits[examples]
-```
+!!! note
 
-This command will install Numba and other packages required to run example scripts.
+    Running the examples requires additional dependencies, such as Numba and NumPy, which can be installed using:
+
+    ```bash
+    pip install evobandits[examples]
+    ```
+
+??? quote "Expand to copy `examples/efficient\_objective\_function.py`"
+
+    ```python
+    --8<-- "examples/efficient_objective_function.py"
+    ```

--- a/docs/source/tutorials/reproducibility.md
+++ b/docs/source/tutorials/reproducibility.md
@@ -1,0 +1,78 @@
+## Random seeding with EvoBandits
+
+Reproducibility in EvoBandits depends on the user’s control over randomness inside the objective function. While the optimization process itself can be seeded, deterministic or reproducible behavior of the objective must also be ensured manually. This can be achieved in different ways:
+
+=== "seeing per evaluation (preferred)"
+
+    Seeding is fully controlled by EvoBandits using a random seed. The `Study` automatically generates an independent, non-negative seed for each evaluation and propagates it to the objective function.
+
+    ```python
+    from evobandits import Study
+
+    def noisy_rosenbrock(number: list, seed: int | None = None):
+        ... # simulation logic
+        return value
+
+    study = Study(seed=42)
+    ```
+
+=== "global seeding"
+
+    A random seed can be applied globally to control the objective function. However, a seed must still be passed to EvoBandits to control the optimization process itself, including sampling and algorithm behavior.
+
+    ```python
+    import random
+    from evobandits import Study
+
+    SEED = 42
+    random.seed(SEED)
+
+    def noisy_rosenbrock(number: list):
+        ... # simulation logic
+        return value
+
+    study = Study(seed=SEED)
+    ```
+
+=== "unseeded (default)"
+
+    By default, no seeding is applied and results are not reproducible.
+
+    ```python
+    from evobandits import Study
+
+    def noisy_rosenbrock(number: list):
+        ... # simulation logic
+        return value
+
+    study = Study()
+    ```
+
+!!! warning "Important: Seeding alone does not guarantee reproducibility. It relies on several factors:"
+
+    - **Consistent configuration**: Even minor changes to the configuration can alter sampling behavior, despite identical seeds. The parameter definitions passed to evobandits (including types, ranges, and value ordering) must remain exactly the same across runs. Similarly, the optimizer setup must also be consistent to avoid hidden sources of variation (e.g. algorithm, budget, number of runs).
+
+    - **Deterministic objective logic**: Your simulation or evaluation code should avoid non-deterministic behavior, such as parallelism, variable I/O timing, or reliance on external systems that may behave inconsistently between runs.
+
+    - **Fully controlled randomness**: All sources of randomness used within your objective or preprocessing logic (e.g., `random`, `numpy.random`, or custom RNGs) must be explicitly seeded to ensure consistent behavior.
+
+    - **Stable environment**: Reproducibility may also depend on your software and hardware environment, including Python version, library versions, operating system, and hardware architecture.
+
+---
+
+## Try it yourself!
+You can experiment with seeding yourself using this simple example from the `evobandits.examples` module, available on [GitHub](https://github.com/EvoBandits/EvoBandits/blob/main/examples/demo_Study.py).
+
+!!! note
+
+    Running the examples requires additional dependencies, such as Numba and NumPy, which can be installed using:
+
+    ```bash
+    pip install evobandits[examples]
+    ```
+
+??? quote "Expand to copy `examples/efficient\_objective\_function.py`"
+
+    ```python
+    --8<-- "examples/efficient_objective_function.py"
+    ```

--- a/docs/source/tutorials/reproducibility.md
+++ b/docs/source/tutorials/reproducibility.md
@@ -2,9 +2,9 @@
 
 Reproducibility in EvoBandits depends on the user’s control over randomness inside the objective function. While the optimization process itself can be seeded, deterministic or reproducible behavior of the objective must also be ensured manually. This can be achieved in different ways:
 
-=== "seeing per evaluation (preferred)"
+=== "seeding per evaluation (preferred)"
 
-    Seeding is fully controlled by EvoBandits using a random seed. The `Study` automatically generates an independent, non-negative seed for each evaluation and propagates it to the objective function.
+    Here, seeding is fully controlled by EvoBandits. If initialized with a random seed, `Study` automatically generates an independent, non-negative seed for each evaluation and propagates it to the objective function.
 
     ```python
     from evobandits import Study
@@ -18,7 +18,7 @@ Reproducibility in EvoBandits depends on the user’s control over randomness in
 
 === "global seeding"
 
-    A random seed can be applied globally to control the objective function. However, a seed must still be passed to EvoBandits to control the optimization process itself, including sampling and algorithm behavior.
+    A random seed can be applied globally to control the objective function. However, a seed must still be passed to `Study` to control the optimization process itself, including sampling and algorithm behavior.
 
     ```python
     import random
@@ -65,7 +65,7 @@ You can experiment with seeding yourself using this simple example from the `evo
 
 !!! note
 
-    Running the examples requires additional dependencies, such as Numba and NumPy, which can be installed using:
+    Running the examples requires additional dependencies, such as NumPy, which can be installed using:
 
     ```bash
     pip install evobandits[examples]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,7 +72,6 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
-  - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Installation: installation.md
   - Tutorials:
       - Efficient Objective Function: tutorials/efficient_objective_function.md
+      - Reproducibility: tutorials/reproducibility.md
   - Reference:
       - Study: references/study.md
       - Params: references/params.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,15 @@ plugins:
             show_source: false
   - privacy
 
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+
 nav:
   - Home: index.md
   - Installation: installation.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,8 @@ plugins:
   - privacy
 
 markdown_extensions:
+  - admonition
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -70,6 +72,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
 
 nav:
   - Home: index.md


### PR DESCRIPTION
Adds a new doc segment on reproducibility, closing #32.

Additions:
* Doc segment on reproducibility that shows users how to reproduce results with seeding.
* Found a neat way to embed large code files, as shown here https://automl.github.io/SMAC3/main/examples/1%20Basics/1_quadratic_function/
* Added extension for python syntax highlighting.
* Applied formatting to other files.

Useful Links: 
* https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#highlight
* https://squidfunk.github.io/mkdocs-material/reference/admonitions/#+type:tip

Preview: 
<img width="1202" height="957" alt="image" src="https://github.com/user-attachments/assets/14337123-92bf-4d9e-8f89-179d86eb8d83" />

<img width="1212" height="568" alt="image" src="https://github.com/user-attachments/assets/787273f6-9d32-4140-bb98-bacfab11cdad" />
